### PR TITLE
CI - Pin poetry pre new installer

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip poetry tox
+          python -m pip install --upgrade pip poetry<1.4.1 tox
       - name: Test with tox
         run: tox -e style
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -31,7 +31,8 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip poetry<1.4.1 tox
+          python -m pip install --upgrade pip poetry tox
+          poetry config installer.modern-installation false
       - name: Test with tox
         run: tox -e style
 
@@ -91,6 +92,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip poetry tox tox-gh-actions
+          poetry config installer.modern-installation false
       - name: Test with tox
         # Only the tox environment specified in the tox.ini gh-actions is run
         run: tox -e py310-coverage 
@@ -117,6 +119,7 @@ jobs:
       - name: "Install dependencies"
         run: |
           python -m pip install --upgrade pip poetry tox tox-gh-actions
+          poetry config installer.modern-installation false
 
       - name: "Login in Github container registry"
         uses: docker/login-action@v2.1.0
@@ -218,7 +221,8 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
       - name: Install dependencies and build the library
         run: |
-          python -m pip install --upgrade pip poetry
+          python -m pip install --upgrade pip 
+          poetry config installer.modern-installation false
           poetry install
           poetry build
           poetry run twine check dist/*
@@ -241,7 +245,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           doc-artifact-name: "documentation-html"
 
-  Release:
+  release:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -221,7 +221,7 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
       - name: Install dependencies and build the library
         run: |
-          python -m pip install --upgrade pip 
+          python -m pip install --upgrade pip poetry
           poetry config installer.modern-installation false
           poetry install
           poetry build


### PR DESCRIPTION
Cannot install pandas with the new poetry installer, until they fix their non-standards-compliant wheel we need do downgrade poetry.