### PR TITLE
FIX - Add self parameter to mock fluent

### DIFF
--- a/tests/fluent/test_serialize_props.py
+++ b/tests/fluent/test_serialize_props.py
@@ -26,7 +26,7 @@ class setup_root:
 
 class MockFluent(_FluentCore):
     class _connection:
-        def scheme_eval():
+        def scheme_eval(self):
             pass
 
     def __init__(self):


### PR DESCRIPTION
The MockFluent class has a method scheme_eval which doesn't currently accept any arguments. Add self to get the tests to pass locally.