### PR TITLE
don't pass xml_declaration to ElementTree in 3.7

### DIFF
--- a/src/ansys/materials/manager/util/matml/matml_from_material.py
+++ b/src/ansys/materials/manager/util/matml/matml_from_material.py
@@ -1,5 +1,6 @@
 """Provides the ``MatmlWriter`` class."""
 import os
+import sys
 from typing import BinaryIO, Dict, Sequence, Union
 import xml.etree.ElementTree as ET
 
@@ -187,6 +188,11 @@ class MatmlWriter:
         else:
             print(f"ElementTree does not have `indent`. Python 3.9+ required!")
 
+    def _xml_write_kwargs(self, **kwargs) -> dict:
+        if sys.version_info.minor == 7:
+            return {}
+        return {"xml_declaration" : kwargs.get("xml_declaration", False)}
+
     def write(self, buffer: BinaryIO, **kwargs) -> None:
         """
         Write a Matml (engineering data xml format) representation of materials to buffer.
@@ -208,7 +214,7 @@ class MatmlWriter:
         if kwargs.get("indent", False):
             self._indent(tree)
         buffer.write(
-            ET.tostring(tree.getroot(), xml_declaration=kwargs.get("xml_declaration", False))
+            ET.tostring(tree.getroot(), **self._xml_write_kwargs(**kwargs))
         )
 
     def export(self, path: _PATH_TYPE, **kwargs) -> None:
@@ -232,4 +238,4 @@ class MatmlWriter:
         print(f"write xml to {path}")
         if kwargs.get("indent", False):
             self._indent(tree)
-        tree.write(path, xml_declaration=kwargs.get("xml_declaration", False))
+        tree.write(path, **self._xml_write_kwargs(**kwargs))

--- a/src/ansys/materials/manager/util/matml/matml_from_material.py
+++ b/src/ansys/materials/manager/util/matml/matml_from_material.py
@@ -191,7 +191,7 @@ class MatmlWriter:
     def _xml_write_kwargs(self, **kwargs) -> dict:
         if sys.version_info.minor == 7:
             return {}
-        return {"xml_declaration" : kwargs.get("xml_declaration", False)}
+        return {"xml_declaration": kwargs.get("xml_declaration", False)}
 
     def write(self, buffer: BinaryIO, **kwargs) -> None:
         """
@@ -213,9 +213,7 @@ class MatmlWriter:
 
         if kwargs.get("indent", False):
             self._indent(tree)
-        buffer.write(
-            ET.tostring(tree.getroot(), **self._xml_write_kwargs(**kwargs))
-        )
+        buffer.write(ET.tostring(tree.getroot(), **self._xml_write_kwargs(**kwargs)))
 
     def export(self, path: _PATH_TYPE, **kwargs) -> None:
         """

--- a/tests/matml/test_matml_from_material.py
+++ b/tests/matml/test_matml_from_material.py
@@ -40,7 +40,8 @@ class TestMatmlFromMaterial:
             assert ET.tostring(tree.getroot()) == ET.tostring(ref_tree.getroot())
 
     @pytest.mark.parametrize("indent", [False, True])
-    def test_matml_from_material(self, indent):
+    @pytest.mark.parametrize("xml_declaration", [False, True])
+    def test_matml_from_material(self, indent, xml_declaration):
         """
         Verify that manually constructed materials can be exported to matml.
         The matml is imported back and the data is compared with the initial values.
@@ -88,11 +89,11 @@ class TestMatmlFromMaterial:
         with tempfile.TemporaryDirectory() as tmpdirname:
             export_path = os.path.join(tmpdirname, "engd.xml")
             matml_writer = MatmlWriter([material])
-            matml_writer.export(export_path, indent=indent)
+            matml_writer.export(export_path, indent=indent, xml_declaration=xml_declaration)
 
             _validate_file(export_path)
 
             write_path = os.path.join(tmpdirname, "engd2.xml")
             with open(write_path, "wb") as f:
-                matml_writer.write(f, indent=indent)
+                matml_writer.write(f, indent=indent, xml_declaration=xml_declaration)
             _validate_file(write_path)


### PR DESCRIPTION
My last patch broke something for 3.7 - this should fix it.

Will patch this into a 0.2.2 release after this lands.